### PR TITLE
Remove dream parent; roles/tools/teams operate independently

### DIFF
--- a/components/screens/Dream/Roles/index.js
+++ b/components/screens/Dream/Roles/index.js
@@ -9,7 +9,7 @@ let RolesScreen = ({ roles }) =>
     <RoleList roles={roles} />
   </ScreenView>
 
-let mapStateToProps = ({ dream: { roles } }) => ({ roles });
+let mapStateToProps = ({ roles }) => ({ roles });
 
 let enhance = compose(
   connect(mapStateToProps)

--- a/components/screens/Dream/Teams/index.js
+++ b/components/screens/Dream/Teams/index.js
@@ -9,7 +9,7 @@ let TeamsScreen = ({ teams }) =>
     <TeamList teams={teams} />
   </ScreenView>
 
-let mapStateToProps = ({ dream: { teams } }) => ({ teams });
+let mapStateToProps = ({ teams }) => ({ teams });
 
 let enhance = compose(
   connect(mapStateToProps)

--- a/components/screens/Dream/Tools/index.js
+++ b/components/screens/Dream/Tools/index.js
@@ -9,7 +9,7 @@ let ToolsScreen = ({ tools }) =>
     <ToolList tools={tools} />
   </ScreenView>
 
-let mapStateToProps = ({ dream: { tools } }) => ({ tools });
+let mapStateToProps = ({ tools }) => ({ tools });
 
 let enhance = compose(
   connect(mapStateToProps)

--- a/store/initial.js
+++ b/store/initial.js
@@ -1,49 +1,47 @@
 const initState = {
   user: 'Joshua Martin',
-  dream: {
-    roles: [
-      {
-        id: 'df0fbreiwej',
-        title: 'Front End Web Developer'
-      },
-      {
-        id: 'cbvidjboi',
-        title: 'Software Engineer'
-      },
-      {
-        id: '409u495bdsp',
-        title: 'UX Designer'
-      }
-    ],
-    tools: [
-      {
-        id: '4wg09brdrh',
-        title: 'Ruby'
-      },
-      {
-        id: '0h9ur0sev',
-        title: 'JavaScript',
-      },
-      {
-        id: 'xoijfuw0h',
-        title: 'Test Driven Development'
-      }
-    ],
-    teams: [
-      {
-        id: 'b9erurenghs',
-        title: 'Airbnb'
-      },
-      {
-        id: 'rg0htrssg4',
-        title: 'Stitch Fix'
-      },
-      {
-        id: '40ih09we',
-        title: 'Apple'
-      }
-    ]
-  },
+  roles: [
+    {
+      id: 'df0fbreiwej',
+      title: 'Front End Web Developer'
+    },
+    {
+      id: 'cbvidjboi',
+      title: 'Software Engineer'
+    },
+    {
+      id: '409u495bdsp',
+      title: 'UX Designer'
+    }
+  ],
+  tools: [
+    {
+      id: '4wg09brdrh',
+      title: 'Ruby'
+    },
+    {
+      id: '0h9ur0sev',
+      title: 'JavaScript',
+    },
+    {
+      id: 'xoijfuw0h',
+      title: 'Test Driven Development'
+    }
+  ],
+  teams: [
+    {
+      id: 'b9erurenghs',
+      title: 'Airbnb'
+    },
+    {
+      id: 'rg0htrssg4',
+      title: 'Stitch Fix'
+    },
+    {
+      id: '40ih09we',
+      title: 'Apple'
+    }
+  ],
   opps: [
     {
       id: 's09dnfobgi',


### PR DESCRIPTION
Sad but not sad. Because a user has only one dream, it makes sense for roles/tools/teams to be related to the user directly.